### PR TITLE
API updates

### DIFF
--- a/compare_models.py
+++ b/compare_models.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+from tqdm import tqdm
 
 from lmentry.constants import PREDICTIONS_ROOT_DIR, TASKS_DATA_DIR, RESULTS_DIR, DEFAULT_MAX_LENGTH
 from lmentry.tasks.lmentry_tasks import get_tasks_names, tasks_list
@@ -57,7 +58,7 @@ def main():
   args = parse_arguments()
   task_names = get_tasks_names(args.task_names)
 
-  for probe_model_name in args.probe_model_names:
+  for probe_model_name in tqdm(args.probe_model_names, desc="Models comparison"):
     model_names = get_short_model_names([args.ref_model_name, probe_model_name])
     print(f"Models {model_names[0]} and {model_names[1]} are compared")
 
@@ -83,11 +84,12 @@ def main():
     )
     logging.info(f"Prediction for {model_names[1]} model finished")
 
-    flexible_scoring(task_names=task_names,
-                    model_names=model_names,
-                    num_processes=args.num_procs,
-                    forced_scoring=args.forced_scoring,
-                    )
+    flexible_scoring(
+      task_names=task_names,
+      model_names=model_names,
+      num_processes=args.num_procs,
+      forced_scoring=args.forced_scoring,
+    )
 
     create_per_task_accuracy_comparison_csv(model_names=model_names, task_names=task_names, certainty=args.certainty)
 

--- a/compare_models.py
+++ b/compare_models.py
@@ -21,7 +21,7 @@ def parse_arguments():
   parser.add_argument('-p', '--probe_model_names', nargs="+", type=str, default="vicuna-7b-v1-3-q4f16_0",
                       help=f"Names of probe models. If the number of the probe models is bigger than one "
                            "it iteratively compares the reference model with each from the list.")
-  parser.add_argument('-t', '--task_names', nargs="+", type=str, default=get_tasks_names("7b"),
+  parser.add_argument('-t', '--task_names', nargs="+", type=str, default=get_tasks_names(["7b"]),
                       help="If need to evaluate specified set of tasks set their names or name(s) of specified task set(s). "
                            f"Task set names should be from the list: {tasks_list.keys()}. "
                            f"Task names should be from the list: {get_tasks_names()}. "

--- a/evaluate_model.py
+++ b/evaluate_model.py
@@ -7,7 +7,7 @@ from lmentry.analysis.accuracy import (
   create_per_task_accuracy_csv,
   create_per_template_accuracy_csv,
 )
-from lmentry.tasks.lmentry_tasks import simple_tasks, all_tasks
+from lmentry.tasks.lmentry_tasks import get_tasks_names, tasks_list
 from lmentry.model_manager import get_short_model_names
 
 
@@ -19,9 +19,10 @@ def parse_arguments():
   parser.add_argument("-m", "--model_names", nargs="+", type=str, default=None,
                       help="Names of models which statistics were collected and should evaluate. "
                            "If it is None the predictions directory is analized and evailable model-statistics are evaluated")
-  parser.add_argument('-t', '--task_names', nargs="+", type=str, default=None,
-                      help="If need to evaluate specified set of tasks set their names. "
-                           f"Task names should be from the list: {all_tasks.keys()}. "
+  parser.add_argument('-t', '--task_names', nargs="+", type=str, default=get_tasks_names(),
+                      help="If need to evaluate specified set of tasks set their names or name(s) of specified task set(s). "
+                           f"Task set names should be from the list: {tasks_list.keys()}. "
+                           f"Task names should be from the list: {get_tasks_names()}. "
                            "It tries to analyze all tasks by default")
   parser.add_argument("-n", "--num-procs",
                       default=1,
@@ -43,13 +44,8 @@ def main():
   RESULTS_DIR.mkdir(exist_ok=True)
 
   args = parse_arguments()
-  if args.simple_tasks:
-    task_names = sorted(simple_tasks.keys())
-  elif args.task_names is not None:
-    task_names = args.task_names
-  else:
-    task_names = sorted(all_tasks.keys())
 
+  task_names = get_tasks_names(args.task_names)
   model_names = get_short_model_names(args.model_names)
 
   logging.info(f"scoring LMentry predictions for models {model_names}")

--- a/evaluate_model.py
+++ b/evaluate_model.py
@@ -49,10 +49,11 @@ def main():
   model_names = get_short_model_names(args.model_names)
 
   logging.info(f"scoring LMentry predictions for models {model_names}")
-  score_all_predictions(task_names=task_names,
-                        model_names=model_names,
-                        num_processes=args.num_procs
-                        )
+  score_all_predictions(
+    task_names=task_names,
+    model_names=model_names,
+    num_processes=args.num_procs
+  )
   logging.info(f"finished scoring all LMentry predictions for models {model_names}")
 
   create_per_task_accuracy_csv(task_names=task_names, model_names=model_names)

--- a/lmentry/analysis/accuracy.py
+++ b/lmentry/analysis/accuracy.py
@@ -4,6 +4,7 @@ import json
 import logging
 from multiprocessing import Pool
 from pathlib import Path
+from tqdm import tqdm
 
 import numpy as np
 
@@ -188,7 +189,7 @@ def create_per_task_accuracy_csv(task_names: list[str] = None, model_names: list
 
     # rest of the rows are task result rows
     task_names = task_names or list(all_tasks)
-    for task_name in task_names:
+    for task_name in tqdm(task_names, desc="Compare model accuracy for specified tasks"):
         row = []
         row.append(task_name)
 
@@ -234,7 +235,7 @@ def create_per_template_accuracy_csv(task_names: list[str] = None, model_names: 
     template_names = []
     for i in range(template_num):
         template_names.append(f"template{i}")
-    for task_name in task_names:
+    for task_name in tqdm(task_names, desc="Compare model accuracy for specified tasks"):
         row = []
         row.append(task_name)
 
@@ -265,7 +266,6 @@ def create_per_template_accuracy_csv(task_names: list[str] = None, model_names: 
 
 
 def score_task_predictions(task_name: str, model_name: str, forced_scoring: bool=False):
-
     task = all_tasks[task_name]()
     task.score_predictions(model_name, forced_scoring=forced_scoring)
 
@@ -336,7 +336,7 @@ def flexible_scoring(task_names: list[str] = None, model_names: list[str] = None
     model_tasks_dict = look_through_predictions_dir(model_names=model_names,
                                                     task_names=task_names)
 
-    for model, tasks in model_tasks_dict.items():
+    for model, tasks in tqdm(model_tasks_dict.items(), desc="Score models"):
         logging.info(f"scoring LMentry predictions for {model}")
         score_all_predictions(task_names=tasks,
                               model_names=[model],

--- a/lmentry/analysis/comparison.py
+++ b/lmentry/analysis/comparison.py
@@ -1,6 +1,7 @@
 import csv
 import logging
 from pathlib import Path
+from tqdm import tqdm
 
 from lmentry.tasks.lmentry_tasks import all_tasks
 from lmentry.constants import RESULTS_DIR
@@ -22,7 +23,7 @@ def create_per_task_accuracy_comparison_csv(
 
   # rest of the rows are task result rows
   task_names = task_names or list(all_tasks)
-  for task_name in task_names:
+  for task_name in tqdm(task_names, desc="Compare model accuracy for specified tasks"):
     row = []
     row.append(task_name)
 

--- a/lmentry/tasks/lmentry_tasks.py
+++ b/lmentry/tasks/lmentry_tasks.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from pathlib import Path
+from typing import List, Union
 
 from lmentry.constants import TASKS_DATA_DIR
 from lmentry.tasks.all_words_from_category import AllWordsFromCategory
@@ -101,7 +102,7 @@ simple_tasks = {
 all_tasks = core_tasks | analysis_tasks | simple_tasks
 
 # It is part from core tasks
-tasks_to_compare = {
+sensetive_7b_model_tasks = {
     "bigger_number": BiggerNumber,
     "smaller_number": SmallerNumber,
     "first_alphabetically": FirstAlphabetically,
@@ -109,30 +110,52 @@ tasks_to_compare = {
     "most_associated_word": MostAssociatedWord,
 }
 
+tasks_list = {
+    "all": all_tasks,
+    "core": core_tasks,
+    "analysis": analysis_tasks,
+    "simple": simple_tasks,
+    "7b": sensetive_7b_model_tasks,
+}
+
+
+def get_tasks_names(task_names: Union[List[str], None]=["all"]):
+  if not task_names:
+    return None
+  ret_task_names = []
+  for task_name in task_names:
+    if task_name in tasks_list.keys():
+      ret_task_names = ret_task_names + sorted(tasks_list[task_name].keys())
+    elif task_name in all_tasks.keys():
+      ret_task_names.append()
+    else:
+      raise ValueError(f"There is no task or task set with name {task_name}")
+  return ret_task_names
+
 
 def create_task_data(task_name: str):
-    task: LMentryTask = all_tasks[task_name]()
-    logging.info(f"creating data for task \"{task_name}\"")
-    task.create_data()
+  task: LMentryTask = all_tasks[task_name]()
+  logging.info(f"creating data for task \"{task_name}\"")
+  task.create_data()
 
 
 def create_all_task_data():
-    for task_name in all_tasks:
-        create_task_data(task_name)
+  for task_name in all_tasks:
+    create_task_data(task_name)
 
 
 def count_examples(tasks_to_count: list[str] = None, tasks_data_dir: Path = None):
-    tasks_data_dir = tasks_data_dir or TASKS_DATA_DIR
+  tasks_data_dir = tasks_data_dir or TASKS_DATA_DIR
 
-    if tasks_to_count is None:
-        tasks_to_count = all_tasks
+  if tasks_to_count is None:
+    tasks_to_count = all_tasks
 
-    n_examples = 0
-    for task_name in tasks_to_count:
-        task_data_path = tasks_data_dir.joinpath(f"{task_name}.json")
-        with open(task_data_path) as f:
-            task_data = json.load(f)
-            n_examples += len(task_data["examples"])
+  n_examples = 0
+  for task_name in tasks_to_count:
+    task_data_path = tasks_data_dir.joinpath(f"{task_name}.json")
+    with open(task_data_path) as f:
+      task_data = json.load(f)
+      n_examples += len(task_data["examples"])
 
-    print(f"#examples in all tasks combined: {n_examples}")
-    return n_examples
+  print(f"#examples in all tasks combined: {n_examples}")
+  return n_examples

--- a/predict_model.py
+++ b/predict_model.py
@@ -1,7 +1,7 @@
 import argparse
 
 from lmentry.predict import generate_all_hf_predictions
-from lmentry.tasks.lmentry_tasks import simple_tasks, all_tasks
+from lmentry.tasks.lmentry_tasks import get_tasks_names, tasks_list
 from lmentry.constants import DEFAULT_MAX_LENGTH
 
 
@@ -9,9 +9,10 @@ def parse_args():
   parser = argparse.ArgumentParser()
   parser.add_argument("-m", "--model_names", nargs="+", type=str, default="vicuna-7b-v1-3",
                       help="Model names or paths to the root directory of mlc-llm models for predictions.")
-  parser.add_argument('-t', '--task_names', nargs="+", type=str, default=None,
-                      help="If need to predict specified set of tasks set their names. "
-                           f"Task names should be from the list: {all_tasks.keys()}. "
+  parser.add_argument('-t', '--task_names', nargs="+", type=str, default=get_tasks_names(),
+                      help="If need to evaluate specified set of tasks set their names or name(s) of specified task set(s). "
+                           f"Task set names should be from the list: {tasks_list.keys()}. "
+                           f"Task names should be from the list: {get_tasks_names()}. "
                            "It tries to analyze all tasks by default")
   parser.add_argument('-d', '--device', type=str, default="cuda",
                       help="Device name. It is needed and used by mlc model only")
@@ -19,8 +20,6 @@ def parse_args():
                       help="For calculation on A10G batch size 100 is recommended. For mlc-llm models batch size is reduced to 1")
   parser.add_argument('-ml', '--max_length', type=int, default=DEFAULT_MAX_LENGTH,
                       help="Input max length")
-  parser.add_argument("-s", "--simple_tasks", action="store_true", default=False,
-                    help="It skips task names list if exist and uses simple tasks")
 
   args = parser.parse_args()
   return args
@@ -29,13 +28,7 @@ def parse_args():
 def main():
   args = parse_args()
 
-  task_names = None
-  if args.simple_tasks:
-    task_names = sorted(simple_tasks.keys())
-  elif args.task_names is not None:
-    task_names = args.task_names
-  else:
-    task_names = sorted(all_tasks.keys())
+  task_names = get_tasks_names(args.task_names)
 
   for model_name in args.model_names:
     print(f"Prediction of tasks for {model_name} model starts")

--- a/predict_model.py
+++ b/predict_model.py
@@ -1,4 +1,5 @@
 import argparse
+from tqdm import tqdm
 
 from lmentry.predict import generate_all_hf_predictions
 from lmentry.tasks.lmentry_tasks import get_tasks_names, tasks_list
@@ -30,7 +31,7 @@ def main():
 
   task_names = get_tasks_names(args.task_names)
 
-  for model_name in args.model_names:
+  for model_name in tqdm(args.model_names, desc="Predict specified models"):
     print(f"Prediction of tasks for {model_name} model starts")
     generate_all_hf_predictions(
       task_names=task_names,

--- a/scoring.py
+++ b/scoring.py
@@ -1,7 +1,7 @@
 import argparse
 
 from lmentry.analysis.accuracy import flexible_scoring
-from lmentry.tasks.lmentry_tasks import all_tasks, simple_tasks
+from lmentry.tasks.lmentry_tasks import get_tasks_names, tasks_list
 from lmentry.model_manager import get_short_model_names
 
 
@@ -14,26 +14,22 @@ def parse_arguments():
                       help="Names of models which statistics were collected and should evaluate. "
                            "If it is None the predictions directory is analized and evailable model-statistics are evaluated")
   parser.add_argument('-t', '--task_names', nargs="+", type=str, default=None,
-                      help="If need to evaluate specified set of tasks set their names. "
-                           f"Task names should be from the list: {all_tasks.keys()}. "
-                           "It tries to analyze all tasks by default")
+                      help="If need to evaluate specified set of tasks set their names or name(s) of specified task set(s). "
+                           f"Task set names should be from the list: {tasks_list.keys()}. "
+                           f"Task names should be from the list: {get_tasks_names()}. "
+                           "By default it tries to score all predicted tasks for specified models")
   parser.add_argument("-n", "--num-procs", type=int, default=1,
                       help="The number of processes to use when scoring the predictions. "
                            "Can be up to the number of models you want to evaluate * 41.")
   parser.add_argument("-f", "--forced_scoring", action="store_true", default=False,
                       help="If scoring has been done for specified task it skips it. This flag allows to redo ready scoring")
-  parser.add_argument("-s", "--simple_tasks", action="store_true", default=False,
-                      help="It skips task names list if exist and uses simple tasks instead of")
   return parser.parse_args()
 
 
 def main():
   args = parse_arguments()
 
-  if args.simple_tasks:
-    task_names = sorted(simple_tasks.keys())
-  else:
-    task_names = args.task_names
+  task_names = get_tasks_names(args.task_names)
 
   model_names = get_short_model_names(args.model_names)
   flexible_scoring(task_names=task_names,


### PR DESCRIPTION
- Update task names preprocessing. Name of task sets (like "simple") can be used instead one for specified task
- Tqdm is used to skipped long logs for each task sample.