### PR TITLE
Small improvements of scorer templates

### DIFF
--- a/compare_models.py
+++ b/compare_models.py
@@ -97,6 +97,7 @@ def main():
       task_names=task_names,
       model_names=model_names,
       num_processes=args.num_procs,
+      use_vllm=args.use_vllm,
       forced_scoring=args.forced_scoring,
     )
 

--- a/lmentry/analysis/accuracy.py
+++ b/lmentry/analysis/accuracy.py
@@ -292,7 +292,7 @@ def score_all_predictions(task_names: list[str] = None, model_names: list[str] =
         pool.starmap(score_task_predictions, starargs)
 
 
-def look_through_predictions_dir(model_names: list[str] = None, task_names: list[str] = None):
+def look_through_predictions_dir(model_names: list[str] = None, task_names: list[str] = None, use_vllm: bool = False):
     model_tasks_dict = {}
     if task_names:
         tasks_path_list = [PREDICTIONS_ROOT_DIR.joinpath(task_name) for task_name in task_names]
@@ -310,7 +310,7 @@ def look_through_predictions_dir(model_names: list[str] = None, task_names: list
         if task_name in all_tasks:
             models_path_list =[]
             if model_names:
-                models_path_list = [task_dir.joinpath(f"{model_name}.json") for model_name in model_names]
+                models_path_list = [task_dir.joinpath(f"{model_name}.json") if not use_vllm else task_dir.joinpath(f"{model_name}.vllm.json") for model_name in model_names]
                 # Check
                 checked_models_path_list = set(models_path_list)
                 for model_path in models_path_list:
@@ -335,7 +335,7 @@ def look_through_predictions_dir(model_names: list[str] = None, task_names: list
 
 
 def flexible_scoring(task_names: list[str] = None, model_names: list[str] = None,
-                     num_processes: int = 1, forced_scoring: bool=False):
+                     num_processes: int = 1, use_vllm: bool=False, forced_scoring: bool=False):
     if not TASKS_DATA_DIR.exists():
         logging.error(f"LMentry tasks data not found at {TASKS_DATA_DIR}. aborting.\n")
         return
@@ -344,7 +344,8 @@ def flexible_scoring(task_names: list[str] = None, model_names: list[str] = None
         return
 
     model_tasks_dict = look_through_predictions_dir(model_names=model_names,
-                                                    task_names=task_names)
+                                                    task_names=task_names,
+                                                    use_vllm=use_vllm)
 
     for model, tasks in tqdm(model_tasks_dict.items(), desc="Score models"):
         logging.info(f"scoring LMentry predictions for {model}")

--- a/lmentry/analysis/accuracy.py
+++ b/lmentry/analysis/accuracy.py
@@ -310,7 +310,7 @@ def look_through_predictions_dir(model_names: list[str] = None, task_names: list
         if task_name in all_tasks:
             models_path_list =[]
             if model_names:
-                models_path_list = [task_dir.joinpath(f"{model_name}.json") if not use_vllm else task_dir.joinpath(f"{model_name}.vllm.json") for model_name in model_names]
+                models_path_list = [task_dir.joinpath(f"{model_name}.json") if not use_vllm else task_dir.joinpath(f"{model_name}_vllm.json") for model_name in model_names]
                 # Check
                 checked_models_path_list = set(models_path_list)
                 for model_path in models_path_list:

--- a/lmentry/scorers/bigger_number_scorer.py
+++ b/lmentry/scorers/bigger_number_scorer.py
@@ -24,6 +24,10 @@ class BiggerNumberScorer(LMentryScorer):
             rf"{answer} is the {bigger} number",
             rf"The {bigger} number is {answer}",
             rf"The {bigger} is {answer}",
+            rf"{distractor}(\s|)<(\s|){answer}",
+            rf"{answer}(\s|)>(\s|){distractor}",
+            rf"The answer is {answer}",
+            rf"The number that is {bigger} than {distractor} is {answer}.",
         ]
         # replace bigger with smaller and swap answer and distractor
         more_base_patterns = [

--- a/lmentry/scorers/bigger_number_scorer.py
+++ b/lmentry/scorers/bigger_number_scorer.py
@@ -26,7 +26,6 @@ class BiggerNumberScorer(LMentryScorer):
             rf"The {bigger} is {answer}",
             rf"{distractor}(\s|)<(\s|){answer}",
             rf"{answer}(\s|)>(\s|){distractor}",
-            rf"The answer is {answer}",
             rf"The number that is {bigger} than {distractor} is {answer}.",
         ]
         # replace bigger with smaller and swap answer and distractor

--- a/lmentry/scorers/most_associated_word_scorer.py
+++ b/lmentry/scorers/most_associated_word_scorer.py
@@ -26,6 +26,7 @@ class MostAssociatedWordScorer(LMentryScorer):
 
         base_patterns = [
             rf"The word {most_associated} {to_} {category} is {answer}",
+            rf"The word {most_associated} {to_} {category} would be {answer}",
             rf"The word {most_associated} {to_} {category} {words} is {answer}",
             rf"The {most_associated} word {to_} {category} is {answer}",
             rf"{category} {is_} {most_associated} {to_} {answer}",

--- a/lmentry/scorers/most_associated_word_scorer.py
+++ b/lmentry/scorers/most_associated_word_scorer.py
@@ -22,17 +22,16 @@ class MostAssociatedWordScorer(LMentryScorer):
 
         to_ = r"(to|with)"
         most_associated = r"(one )?most( commonly)? (associated|related)"
-        is_ = r"(is|are)"  # for words like "pants"
+        is_ = r"(is|are|would be)"  # for words like "pants"
 
         base_patterns = [
-            rf"The word {most_associated} {to_} {category} is {answer}",
-            rf"The word {most_associated} {to_} {category} would be {answer}",
-            rf"The word {most_associated} {to_} {category} {words} is {answer}",
-            rf"The {most_associated} word {to_} {category} is {answer}",
+            rf"The word {most_associated} {to_} {category} {is_} {answer}",
+            rf"The word {most_associated} {to_} {category} {words} {is_} {answer}",
+            rf"The {most_associated} word {to_} {category} {is_} {answer}",
             rf"{category} {is_} {most_associated} {to_} {answer}",
             rf"{answer} {is_} the {most_associated} {to_} {category}",
             rf"{answer} {is_} the word {most_associated} {to_} {category}",
-            rf"The word that relates to {category} the most is {answer}",
+            rf"The word that relates to {category} the most {is_} {answer}",
             rf"{answer} relates to {category} the most",
         ]
         # swap answer and category

--- a/lmentry/scorers/scorer.py
+++ b/lmentry/scorers/scorer.py
@@ -108,12 +108,18 @@ class LMentryScorer:
 
     @staticmethod
     def get_shared_patterns(target):
+        
+        delimiter = r"(:|-)"
+        constructions = r"(this is|it is|it's)"
+        linking = r"(obviously|certainly|definitely|plainly|of course|undoubtedly)"
+        specific = r"(letter|number|word|sentence)"
 
         patterns = [
-            rf"{target} is the answer",
-            rf"The answer is {target}",
-            rf"The correct answer is {target}",
-            rf"Answer: {target}"
+            rf"['\"]?{target}['\"]? is the answer",
+            rf"The answer is ['\"]?{target}['\"]?",
+            rf"The correct answer is ['\"]?{target}['\"]?",
+            rf"Answer(\s|){delimiter}(\s|)['\"]?{target}['\"]?",
+            rf"{linking},(\s|)?{constructions}(\s|)?(the)?(\s|)?({specific})?(\s|)?['\"]?{target}['\"]?",
         ]
         return [p.format(target=target) for p in patterns]
 

--- a/lmentry/scorers/scorer.py
+++ b/lmentry/scorers/scorer.py
@@ -113,13 +113,15 @@ class LMentryScorer:
         constructions = r"(this is|it is|it's)"
         linking = r"(obviously|certainly|definitely|plainly|of course|undoubtedly)"
         specific = r"(letter|number|word|sentence)"
+        r_target = r"['\"]?{target}['\"]?"
+        is_ = r"(is|are)"  # for words like "pants"
 
         patterns = [
-            rf"['\"]?{target}['\"]? is the answer",
-            rf"The answer is ['\"]?{target}['\"]?",
-            rf"The correct answer is ['\"]?{target}['\"]?",
-            rf"Answer(\s|){delimiter}(\s|)['\"]?{target}['\"]?",
-            rf"{linking},(\s|)?{constructions}(\s|)?(the)?(\s|)?({specific})?(\s|)?['\"]?{target}['\"]?",
+            rf"{r_target} {is_} the answer",
+            rf"The answer {is_} {r_target}",
+            rf"The correct answer {is_} {r_target}",
+            rf"Answer(\s|){delimiter}(\s|){r_target}",
+            rf"{linking},(\s|)?{constructions}(\s|)?(the)?(\s|)?({specific})?(\s|)?{r_target}",
         ]
         return [p.format(target=target) for p in patterns]
 

--- a/scoring.py
+++ b/scoring.py
@@ -21,6 +21,8 @@ def parse_arguments():
   parser.add_argument("-n", "--num-procs", type=int, default=1,
                       help="The number of processes to use when scoring the predictions. "
                            "Can be up to the number of models you want to evaluate * 41.")
+  parser.add_argument('--use_vllm', type=bool, default=False,
+                      help="Whether to score vLLM predictions.")
   parser.add_argument("-f", "--forced_scoring", action="store_true", default=False,
                       help="If scoring has been done for specified task it skips it. This flag allows to redo ready scoring")
   return parser.parse_args()
@@ -36,6 +38,7 @@ def main():
     task_names=task_names,
     model_names=model_names,
     num_processes=args.num_procs,
+    use_vllm=args.use_vllm,
     forced_scoring=args.forced_scoring
   )
 


### PR DESCRIPTION
**Motivation:** Found several scorer errors for "bigger number", "first letter" and "most associated word" tasks. 
**Examples of incorrect scoring**:

- Bigger number:

```
1. input: "Q: Of the numbers 251 and 568, which is bigger?\nA:",
prediction: "The number that is bigger than 251 is 568.",
score: 0
certainty: 0

2. input: "From the numbers 501 and 766, write the bigger number:\n",
prediction: "\n501 < 766",
score: 0
certainty: 0

3. input: "From the numbers 645 and 564, write the bigger number:\n",
prediction: "*/\n645 > 564",
score: 0
certainty: 0

4. "input": "From the numbers 874 and 898, write the bigger number:\n",
prediction: "obviously, it is 898.
score: 0
certainty: 0
```

- First letter:

```
1. input: "Write the first letter of the word \"desert\":\n",
prediction: "obviously, this is the letter \"d\".",
score: 0
certainty: 0
```

- Most associated word:

```
1. input: "Q: Of the words \"peach\", \"apple\", \"pineapple\", \"fish\", and \"mango\", what is the word most commonly associated with \"animals\"?\nA:",
prediction: "The word most commonly associated with \"animals\" would be \"fish\".",
score: 0
certainty: 0
```

After the fix, all the examples above are now counting as right answers to the question.
